### PR TITLE
Add open layout for book section

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,34 @@
       <p class="message"></p>
     </div>
   </section>
+  <section class="parallax books-section">
+    <div class="books-container">
+      <div class="book">
+        <img src="https://picsum.photos/300/450?random=101" alt="Book cover 1">
+        <button class="close" aria-label="閉じる">&times;</button>
+        <div class="info">
+          <h3>Book Title 1</h3>
+          <p>ここに本1の紹介文が入ります。</p>
+        </div>
+      </div>
+      <div class="book">
+        <img src="https://picsum.photos/300/450?random=102" alt="Book cover 2">
+        <button class="close" aria-label="閉じる">&times;</button>
+        <div class="info">
+          <h3>Book Title 2</h3>
+          <p>ここに本2の紹介文が入ります。</p>
+        </div>
+      </div>
+      <div class="book">
+        <img src="https://picsum.photos/300/450?random=103" alt="Book cover 3">
+        <button class="close" aria-label="閉じる">&times;</button>
+        <div class="info">
+          <h3>Book Title 3</h3>
+          <p>ここに本3の紹介文が入ります。</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <footer>
     <p>&copy; <span id="current-year"></span> Aoi Nakanishi</p>

--- a/script.js
+++ b/script.js
@@ -142,4 +142,23 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleIndicator();
     document.addEventListener('scroll', toggleIndicator);
   }
+
+  // Book section interactions
+  const booksSection = document.querySelector('.books-section');
+  const books = document.querySelectorAll('.books-section .book');
+  books.forEach(book => {
+    const close = book.querySelector('.close');
+    book.addEventListener('click', () => {
+      books.forEach(b => b.classList.remove('active'));
+      book.classList.add('active');
+      booksSection.classList.add('open');
+    });
+    if (close) {
+      close.addEventListener('click', e => {
+        e.stopPropagation();
+        book.classList.remove('active');
+        booksSection.classList.remove('open');
+      });
+    }
+  });
 });

--- a/style.css
+++ b/style.css
@@ -199,6 +199,80 @@ footer .social-icons svg {
   pointer-events: none;
 }
 
+.books-section {
+  background: url(https://picsum.photos/1600/900?blur=2) center/cover fixed no-repeat;
+}
+
+.books-container {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+.book {
+  position: relative;
+  width: 200px;
+  cursor: pointer;
+  transform: skewY(-8deg);
+  transition: transform 0.5s;
+}
+
+.book img {
+  width: 100%;
+  display: block;
+}
+
+.book .info {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: calc(100% + 20px);
+  width: 250px;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 20px;
+  text-align: left;
+}
+
+.book .close {
+  display: none;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.books-section.open .book:not(.active) {
+  display: none;
+}
+
+.books-section.open .book.active {
+  display: flex;
+  align-items: flex-start;
+  transform: none;
+  gap: 20px;
+}
+
+.books-section.open .book.active img {
+  width: 200px;
+}
+
+.books-section.open .book.active .info {
+  position: static;
+  width: auto;
+  display: block;
+}
+
+.books-section.open .book.active .close {
+  display: block;
+}
+
 @media (max-width: 768px) {
   header.hero,
   .parallax {


### PR DESCRIPTION
## Summary
- refine book showcase container width and background
- hide unselected books and show description beside the active one
- toggle `.open` on the books section in the script

## Testing
- `git status --short`