### PR TITLE
Fix book section layout on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -303,4 +303,29 @@ footer .social-icons svg {
   .parallax {
     background-attachment: scroll;
   }
+
+  .books-section.open .book.active {
+    flex-direction: column;
+    width: 100%;
+    height: calc(var(--vh, 1vh) * 100);
+    margin: 0;
+  }
+
+  .books-section.open .book.active img {
+    width: 100%;
+    height: 50%;
+    object-fit: contain;
+  }
+
+  .books-section.open .book.active .info {
+    width: 100%;
+    height: 50%;
+    overflow-y: auto;
+  }
+
+  .books-section.open .book.active .close {
+    top: 10px;
+    left: 10px;
+    z-index: 3;
+  }
 }


### PR DESCRIPTION
## Summary
- adjust the open state of the book section for small screens
- keep cover image on top and details on bottom for mobile

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*