### PR TITLE
Change fadeSlide for smoother transitions

### DIFF
--- a/style.css
+++ b/style.css
@@ -130,6 +130,7 @@ footer .social-icons svg {
   height: 100%;
   background-size: cover;
   background-position: center;
+  transform-origin: center;
   opacity: 0;
   animation: fadeSlide 15s infinite;
 }
@@ -149,23 +150,23 @@ footer .social-icons svg {
 @keyframes fadeSlide {
   0% {
     opacity: 0;
-    transform: translateX(100%);
+    transform: translateX(60%) scale(1);
   }
   10% {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateX(0) scale(1);
   }
   30% {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateX(0) scale(1);
   }
   40% {
     opacity: 0;
-    transform: translateX(-10%);
+    transform: scale(1.2);
   }
   100% {
     opacity: 0;
-    transform: translateX(-10%);
+    transform: scale(1.2);
   }
 }
 


### PR DESCRIPTION
## Summary
- start project one backgrounds slightly inside the screen
- fade and scale out departing images instead of sliding left
- add `transform-origin: center` for better scaling

## Testing
- `git status --short`