### PR TITLE
Remove dark overlay when selecting books

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
         </div>
       </div>
     </div>
-    <div class="modal-overlay"></div>
   </section>
 
   <section class="works-section">

--- a/script.js
+++ b/script.js
@@ -146,7 +146,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Book section interactions
   const booksSection = document.querySelector('.books-section');
-  const overlay = document.querySelector('.books-section .modal-overlay');
   const books = document.querySelectorAll('.books-section .book');
   books.forEach(book => {
     const close = book.querySelector('.close');
@@ -167,12 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  if (overlay) {
-    overlay.addEventListener('click', () => {
-      booksSection.classList.remove('open');
-      books.forEach(b => b.classList.remove('active'));
-    });
-  }
+  // Clicking outside no longer needed for closing books
 
   // Works section interactions
   const worksSection = document.querySelector('.works-section');

--- a/style.css
+++ b/style.css
@@ -207,10 +207,28 @@ footer .social-icons svg {
 .books-section {
   position: relative;
   background: #111;
-  background-image: url('images/typewriter.webp');
   padding: 60px 0;
   scroll-snap-align: start;
+  overflow: hidden;
 }
+
+.books-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url('images/typewriter.webp');
+  background-size: cover;
+  background-position: center;
+  background-attachment: inherit;
+  filter: grayscale(100%);
+  z-index: 0;
+}
+
+.books-section .books-container {
+  position: relative;
+  z-index: 1;
+}
+
 
 .books-section.open {
   padding: 0;
@@ -233,10 +251,6 @@ footer .social-icons svg {
   background: rgba(0, 0, 0, 0.6);
 }
 
-.books-section.open .modal-overlay {
-  display: block;
-  z-index: 1;
-}
 
 .book {
   position: relative;


### PR DESCRIPTION
## Summary
- remove the modal overlay div from the Books section
- drop related CSS rules and event handling
- keep grayscale background effect for the typewriter image

## Testing
- `git status --short`
