### PR TITLE
Fix Books heading position

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     </div>
   </section>
   <section class="parallax books-section">
+    <h2>Books</h2>
     <div class="books-container">
       <div class="book">
         <img src="https://m.media-amazon.com/images/I/51YiniQHk5L._SY445_SX342_PQ76_.jpg" alt="Book cover 1">

--- a/style.css
+++ b/style.css
@@ -220,6 +220,18 @@ section img.loaded {
   padding: 60px 0;
   scroll-snap-align: start;
   overflow: hidden;
+  display: block; /* override flex layout from .parallax */
+}
+
+/* Stylized heading for books section */
+.books-section h2 {
+  font-family: 'Bebas Neue', cursive;
+  font-size: 4rem;
+  margin: 0 0 40px;
+  text-align: center;
+  letter-spacing: 2px;
+  position: relative;
+  z-index: 1;
 }
 
 .books-section::before {


### PR DESCRIPTION
## Summary
- ensure the Books heading sits above the parallax background
- keep the heading style consistent with other sections

## Testing
- `git status --short`
