### PR TITLE
Fix panorama scroll sync on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -34,31 +34,25 @@ document.addEventListener('DOMContentLoaded', () => {
   sections.forEach(section => observer.observe(section));
 
   const worksPanorama = document.querySelector('.works-section');
-  let worksStart = 0;
-  let worksEnd = 0;
-
-  function updateWorksBounds() {
-    if (!worksPanorama) return;
-    worksStart = worksPanorama.offsetTop;
-    worksEnd = worksStart + worksPanorama.offsetHeight - window.innerHeight;
-  }
 
   function updatePanorama() {
     if (!worksPanorama) return;
+    const rect = worksPanorama.getBoundingClientRect();
+    const distance = rect.height - window.innerHeight;
+    if (distance <= 0) {
+      worksPanorama.style.backgroundPositionX = '100%';
+      return;
+    }
     const progress = Math.min(
-      Math.max((window.scrollY - worksStart) / (worksEnd - worksStart), 0),
+      Math.max((0 - rect.top) / distance, 0),
       1
     );
     // Move panorama left as user scrolls down
     worksPanorama.style.backgroundPositionX = `${progress * 100}%`;
   }
 
-  updateWorksBounds();
   updatePanorama();
-  window.addEventListener('resize', () => {
-    updateWorksBounds();
-    updatePanorama();
-  });
+  window.addEventListener('resize', updatePanorama);
   document.addEventListener('scroll', updatePanorama);
 
   // Project One background images


### PR DESCRIPTION
## Summary
- ensure panorama background reaches end when the section ends by calculating progress based on bounding box

## Testing
- `true`